### PR TITLE
feat: add possibility to customize picker opts at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,26 @@ require('seeker').setup({
 })
 ```
 
+#### Picker Options Precedence
+
+Picker options are merged in the following order (later overrides earlier):
+
+1. **setup() picker_opts** - Options set during plugin setup
+2. **seek() picker_opts** - Options passed when calling seek programmatically
+
+```lua
+-- Options set during setup have medium precedence
+require("seeker").setup({
+    picker_opts = { focus = "list" }
+})
+
+-- Options passed here have the highest precedence if you call seek with Lua code
+require("seeker").seek({
+    mode = "files",
+    picker_opts = { focus = "input", pattern = "foobar" },
+})
+```
+
 ### Commands
 
 The `:Seeker` command accepts an optional mode argument with tab completion:

--- a/lua/seeker/backends/snacks.lua
+++ b/lua/seeker/backends/snacks.lua
@@ -8,7 +8,8 @@ local Snacks = require('snacks')
 
 ---Toggle from file mode to grep mode
 ---@param picker table Snacks picker object
-local function toggle_to_grep(picker)
+---@param custom_picker_opts table Picker options to override defaults
+local function toggle_to_grep(picker, custom_picker_opts)
     local items = utils.get_picker_items(picker)
 
     if #items == 0 then
@@ -27,13 +28,14 @@ local function toggle_to_grep(picker)
     picker:close()
 
     vim.schedule(function()
-        M.create_grep_picker()
+        M.create_grep_picker(custom_picker_opts)
     end)
 end
 
 ---Toggle from grep mode to file mode
 ---@param picker table Snacks picker object
-local function toggle_to_file(picker)
+---@param custom_picker_opts table Picker options to verride defaults
+local function toggle_to_file(picker, custom_picker_opts)
     local items = utils.get_picker_items(picker)
 
     if #items == 0 then
@@ -52,21 +54,23 @@ local function toggle_to_file(picker)
     picker:close()
 
     vim.schedule(function()
-        M.create_file_picker()
+        M.create_file_picker(custom_picker_opts)
     end)
 end
 
 ---Create a file picker
+---@param custom_picker_opts table Picker options to override defaults
 ---@param mode string? 'git_files' or 'files' (auto-detect if nil)
-M.create_file_picker = function(mode)
+M.create_file_picker = function(custom_picker_opts, mode)
     local config = config_module.get()
     local grep_files = state.get_grep_results()
 
     local picker_opts = vim.tbl_deep_extend('force', config.picker_opts or {}, {})
+    picker_opts = vim.tbl_deep_extend('force', picker_opts, custom_picker_opts or {})
 
     picker_opts.actions = picker_opts.actions or {}
     picker_opts.actions.seeker_toggle = function(picker)
-        toggle_to_grep(picker)
+        toggle_to_grep(picker, custom_picker_opts)
     end
 
     picker_opts.win = picker_opts.win or {}
@@ -110,11 +114,13 @@ M.create_file_picker = function(mode)
 end
 
 ---Create a grep picker
-M.create_grep_picker = function()
+---@param custom_picker_opts table Picker options to override defaults
+M.create_grep_picker = function(custom_picker_opts)
     local config = config_module.get()
     local file_list = state.get_files()
 
     local picker_opts = vim.tbl_deep_extend('force', config.picker_opts or {}, {})
+    picker_opts = vim.tbl_deep_extend('force', picker_opts, custom_picker_opts or {})
 
     picker_opts.actions = picker_opts.actions or {}
     picker_opts.actions.seeker_toggle = function(picker)

--- a/lua/seeker/backends/telescope.lua
+++ b/lua/seeker/backends/telescope.lua
@@ -50,7 +50,8 @@ end
 
 ---Toggle from file mode to grep mode
 ---@param prompt_bufnr number Buffer number
-local function toggle_to_grep(prompt_bufnr)
+---@param custom_picker_opts table Picker options to override defaults
+local function toggle_to_grep(prompt_bufnr, custom_picker_opts)
     local action_state = require('telescope.actions.state')
     local actions = require('telescope.actions')
 
@@ -73,13 +74,14 @@ local function toggle_to_grep(prompt_bufnr)
     actions.close(prompt_bufnr)
 
     vim.schedule(function()
-        M.create_grep_picker()
+        M.create_grep_picker(custom_picker_opts)
     end)
 end
 
 ---Toggle from grep mode to file mode
 ---@param prompt_bufnr number Buffer number
-local function toggle_to_file(prompt_bufnr)
+---@param custom_picker_opts table Picker options to override defaults
+local function toggle_to_file(prompt_bufnr, custom_picker_opts)
     local action_state = require('telescope.actions.state')
     local actions = require('telescope.actions')
 
@@ -102,21 +104,23 @@ local function toggle_to_file(prompt_bufnr)
     actions.close(prompt_bufnr)
 
     vim.schedule(function()
-        M.create_file_picker()
+        M.create_file_picker(custom_picker_opts)
     end)
 end
 
 ---Create a file picker
+---@param custom_picker_opts table Picker options to override defaults
 ---@param mode string? 'git_files' or 'files' (auto-detect if nil)
-M.create_file_picker = function(mode)
+M.create_file_picker = function(custom_picker_opts, mode)
     local config = config_module.get()
     local grep_files = state.get_grep_results()
 
     local opts = vim.tbl_deep_extend('force', config.picker_opts or {}, {})
+    opts = vim.tbl_deep_extend('force', opts, custom_picker_opts or {})
 
     opts.attach_mappings = function(prompt_bufnr, map)
         map({ 'i', 'n' }, config.toggle_key, function()
-            toggle_to_grep(prompt_bufnr)
+            toggle_to_grep(prompt_bufnr, opts)
         end)
         return true
     end
@@ -156,16 +160,18 @@ M.create_file_picker = function(mode)
 end
 
 ---Create a grep picker
-M.create_grep_picker = function()
+---@param custom_picker_opts table Picker options to override defaults
+M.create_grep_picker = function(custom_picker_opts)
     local config = config_module.get()
     local file_list = state.get_files()
     local builtin = require('telescope.builtin')
 
     local opts = vim.tbl_deep_extend('force', config.picker_opts or {}, {})
+    opts = vim.tbl_deep_extend('force', opts, custom_picker_opts or {})
 
     opts.attach_mappings = function(prompt_bufnr, map)
         map({ 'i', 'n' }, config.toggle_key, function()
-            toggle_to_file(prompt_bufnr)
+            toggle_to_file(prompt_bufnr, opts)
         end)
         return true
     end

--- a/lua/seeker/picker.lua
+++ b/lua/seeker/picker.lua
@@ -12,13 +12,14 @@ M.seek = function(opts)
 
     local backend = backends.get_backend()
     local mode = opts.mode
+    local picker_opts = opts.picker_opts or {}
 
     if mode == 'grep' then
-        backend.create_grep_picker()
+        backend.create_grep_picker(picker_opts)
     elseif mode == 'files' or mode == 'git_files' then
-        backend.create_file_picker(mode)
+        backend.create_file_picker(picker_opts, mode)
     else
-        backend.create_file_picker()
+        backend.create_file_picker(picker_opts)
     end
 end
 


### PR DESCRIPTION
## What does the PR do? (Required)

- [x] Added possibility to customize `picker_opts` at runtime

I have a custom function to be able to pre-fill the search with what is selected in visual mode.

With snacks.nvim, I could do something like:

```lua
{
  "<M-f>",
  function()
    Snacks.picker.grep({ search = selector.get_selected_text() })
  end,
  mode = "v",
  noremap = true,
  silent = true,
  desc = "Find pattern in all files (Alt+f)",
},
```

So the idea is to be able to invoke seeker with customized picker options so that I can inject the selected text, so something like this:

```lua
{
  "<M-f>",
  function()
    require("seeker").seek({
      mode = "grep",
      picker_opts = { search = selector.get_selected_text() }
    })
  end,
  mode = "v",
  noremap = true,
  silent = true,
  desc = "Find pattern in all files (Alt+f)",
},
```

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [x] I have added relevant documentation and tests for the changes
- [x] I have followed the style guidelines of this project

## Evidence (Required)

https://github.com/user-attachments/assets/7d82fcfe-66cc-47cc-beff-b64a73c86741